### PR TITLE
fix(android/ios): disable close FD on android & iOS.

### DIFF
--- a/src/platform/posix/fd.rs
+++ b/src/platform/posix/fd.rs
@@ -113,6 +113,7 @@ impl IntoRawFd for Fd {
     }
 }
 
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 impl Drop for Fd {
     fn drop(&mut self) {
         unsafe {


### PR DESCRIPTION
FD in Android and iOS is created by Android & iOS itself, not by rust code.
So, we can't close the FD from Rust, it should be done from Android & iOS