### PR TITLE
feat(appstore): support mac on appstore.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "TUN device creation and handling."
 repository = "https://github.com/meh/rust-tun"
 keywords = ["tun", "network", "tunnel", "bindings"]
 
+
 [dependencies]
 byteorder = { version = "1", optional = true }
 bytes = { version = "1", optional = true }
@@ -32,6 +33,7 @@ packet = "0.1"
 
 [features]
 async = ["tokio", "tokio-util", "bytes", "byteorder", "futures-core"]
+appstore = []
 
 [[example]]
 name = "read-async"

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -22,9 +22,14 @@ pub mod linux;
 #[cfg(target_os = "linux")]
 pub use self::linux::{create, Configuration, Device, Queue};
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "appstore"))]
+pub mod ios;
+#[cfg(all(target_os = "macos", feature = "appstore"))]
+pub use self::ios::{create, Configuration, Device, Queue};
+
+#[cfg(all(target_os = "macos", not(feature = "appstore")))]
 pub mod macos;
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(feature = "appstore")))]
 pub use self::macos::{create, Configuration, Device, Queue};
 
 #[cfg(target_os = "ios")]


### PR DESCRIPTION
For mac app to be distributed on appstore, it must create the TUN device from the native language (Swift, objective C).
So, macos app on appstore need to use iOS driver which do that thing.

relates to https://github.com/threefoldtech/mycelium/issues/428#issuecomment-2355004389